### PR TITLE
typo fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
 
 
         <footer id="contentinfo" class="body">
-                    All logo's are used with permisson of their respective owner(s).
+                    All logos are used with permission of their respective owner(s).
         </footer><!-- /#contentinfo -->
 
 </body>


### PR DESCRIPTION
Typo: permisson => permission
Plural of logo is logos, see for example http://en.wikipedia.org/wiki/Logo

It's on all pages but I guess they're all generated from some template?
